### PR TITLE
Add support for callable names in field's arguments - default and onupdate

### DIFF
--- a/ramses/acl.py
+++ b/ramses/acl.py
@@ -8,7 +8,7 @@ from pyramid.security import (
 from nefertari.acl import SelfParamMixin
 
 from .views import collection_methods, item_methods
-from . import registry
+from .utils import resolve_to_callable, is_callable_tag
 
 
 log = logging.getLogger(__name__)
@@ -84,9 +84,8 @@ def parse_acl(acl_string, methods_map):
         princ_str = princ_str.strip().lower()
         if princ_str in special_principals:
             principal = special_principals[princ_str]
-        elif princ_str.startswith('{{'):
-            princ_str = princ_str.strip('{{').strip('}}').strip()
-            principal = registry.get(princ_str)
+        elif is_callable_tag(princ_str):
+            principal = resolve_to_callable(princ_str)
         else:
             principal = 'g:' + princ_str
 

--- a/ramses/models.py
+++ b/ramses/models.py
@@ -123,13 +123,14 @@ def generate_model_cls(schema, model_name, raml_resource, es_based=True):
         }
         field_kwargs.update(props.get('args', {}) or {})
 
-        default = field_kwargs.get('default')
-        if is_callable_tag(default):
-            field_kwargs['default'] = resolve_to_callable(default)
+        for default_attr_key in ('default', 'onupdate'):
+            value = field_kwargs.get(default_attr_key)
+            if is_callable_tag(value):
+                field_kwargs[default_attr_key] = resolve_to_callable(value)
 
-        for proc_key in ('before_validation', 'after_validation'):
-            processors = field_kwargs.get(proc_key, [])
-            field_kwargs[proc_key] = [
+        for processor_key in ('before_validation', 'after_validation'):
+            processors = field_kwargs.get(processor_key, [])
+            field_kwargs[processor_key] = [
                 resolve_to_callable(name) for name in processors]
 
         raml_type = (props.get('type', 'string') or 'string').lower()

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -66,14 +66,14 @@ class TestACLHelpers(object):
         mock_perms.assert_called_once_with(['all'], self.methods_map)
         assert perms == [(Allow, 'g:admin', 'Foo')]
 
-    @patch.object(acl, 'registry')
+    @patch.object(acl, 'resolve_to_callable')
     @patch.object(acl, 'methods_to_perms')
-    def test_parse_acl_callable_principal(self, mock_perms, mock_registry):
+    def test_parse_acl_callable_principal(self, mock_perms, mock_res):
         mock_perms.return_value = 'Foo'
-        mock_registry.get.return_value = 'registry callable'
+        mock_res.return_value = 'registry callable'
         perms = acl.parse_acl('allow {{my_user}} all', self.methods_map)
         mock_perms.assert_called_once_with(['all'], self.methods_map)
-        mock_registry.get.assert_called_once_with('my_user')
+        mock_res.assert_called_once_with('{{my_user}}')
         assert perms == [(Allow, 'registry callable', 'Foo')]
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -71,7 +71,8 @@ class TestGenerateModelCls(object):
             'nested_relationships': ['nested_field1']
         }
 
-    def test_simple_case(self, mock_reg):
+    @patch('ramses.models.resolve_to_callable')
+    def test_simple_case(self, mock_res, mock_reg):
         from ramses import models
         schema = self._test_schema()
         schema['properties']['progress'] = {
@@ -83,7 +84,7 @@ class TestGenerateModelCls(object):
                 "after_validation": ["foo"]
             }
         }
-        mock_reg.get.return_value = 1
+        mock_res.return_value = 1
         mock_reg.mget.return_value = {'foo': 'bar'}
         model_cls, auth_model = models.generate_model_cls(
             schema=schema, model_name='Story', raml_resource=None)
@@ -100,7 +101,7 @@ class TestGenerateModelCls(object):
         models.engine.FloatField.assert_called_once_with(
             default=0, required=True, before_validation=[1],
             after_validation=[1])
-        mock_reg.get.assert_has_calls([call('zoo'), call('foo')])
+        mock_res.assert_has_calls([call('zoo'), call('foo')])
         mock_reg.mget.assert_called_once_with('Story')
 
     def test_auth_model(self, mock_reg):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -368,3 +368,37 @@ class TestUtils(object):
         parent = Mock(securedBy=None, parentResource=None)
         resource = Mock(securedBy=None, parentResource=parent)
         assert utils.closest_secured_by(resource) == []
+
+    def test_is_callable_tag_not_str(self):
+        assert not utils.is_callable_tag(1)
+        assert not utils.is_callable_tag(None)
+
+    def test_is_callable_tag_not_tag(self):
+        assert not utils.is_callable_tag('foobar')
+
+    def test_is_callable_tag(self):
+        assert utils.is_callable_tag('{{foobar}}')
+
+    def test_resolve_to_callable_not_found(self):
+        with pytest.raises(ImportError) as ex:
+            utils.resolve_to_callable('{{foobar}}')
+        assert str(ex.value) == 'Failed to load callable `foobar`'
+
+    def test_resolve_to_callable_registry(self):
+        from ramses import registry
+
+        @registry.add
+        def foo():
+            pass
+
+        func = utils.resolve_to_callable('{{foo}}')
+        assert func is foo
+        func = utils.resolve_to_callable('foo')
+        assert func is foo
+
+    def test_resolve_to_callable_dotted_path(self):
+        from datetime import datetime
+        func = utils.resolve_to_callable('{{datetime.datetime}}')
+        assert func is datetime
+        func = utils.resolve_to_callable('datetime.datetime')
+        assert func is datetime


### PR DESCRIPTION
* Add support for callable names in field's arguments - default and onupdate
* Processors, field default & onupdate can now specify callable name as dotted import path. E.g. `{{datetime.datetime.utcnow``