### PR TITLE
Parse new compliant JSON schemas draft 4

### DIFF
--- a/ramses/models.py
+++ b/ramses/models.py
@@ -3,8 +3,8 @@ import logging
 from nefertari import engine
 
 from .utils import (
-    resolve_to_callable, is_callable_tag, resource_schema,
-    generate_model_name, clean_db_properties)
+    resolve_to_callable, is_callable_tag,
+    resource_schema, generate_model_name)
 from . import registry
 
 
@@ -118,7 +118,7 @@ def generate_model_cls(schema, model_name, raml_resource, es_based=True):
         if db_settings is None:
             continue
 
-        field_kwargs = clean_db_properties(db_settings)
+        field_kwargs = db_settings.copy()
         field_kwargs['required'] = bool(field_kwargs.get('required'))
 
         for default_attr_key in ('default', 'onupdate'):

--- a/ramses/scaffolds/ramses_starter/items.json
+++ b/ramses/scaffolds/ramses_starter/items.json
@@ -1,22 +1,30 @@
 {
     "type": "object",
     "title": "Item schema",
-    "$schema": "http://json-schema.org/draft-03/schema",
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "required": ["id", "name"],
     "properties": {
         "id": {
-            "required": true,
-            "type": "id_field",
-            "args": {
-                "primary_key": true
+            "type": ["integer", "null"],
+            "_db_settings": {
+                "_required": true,
+                "_type": "id_field",
+                "_primary_key": true
             }
         },
         "name": {
-            "required": true,
-            "type": "string"
+            "type": "string",
+            "_db_settings": {
+                "_type": "string",
+                "_required": true
+            }
         },
         "description": {
-            "required": false,
-            "type": "text"
+            "type": ["string", "null"],
+            "_db_settings": {
+                "_type": "text",
+                "_required": false
+            }
         }
     }
 }

--- a/ramses/scaffolds/ramses_starter/items.json
+++ b/ramses/scaffolds/ramses_starter/items.json
@@ -7,23 +7,23 @@
         "id": {
             "type": ["integer", "null"],
             "_db_settings": {
-                "_required": true,
-                "_type": "id_field",
-                "_primary_key": true
+                "required": true,
+                "type": "id_field",
+                "primary_key": true
             }
         },
         "name": {
             "type": "string",
             "_db_settings": {
-                "_type": "string",
-                "_required": true
+                "type": "string",
+                "required": true
             }
         },
         "description": {
             "type": ["string", "null"],
             "_db_settings": {
-                "_type": "text",
-                "_required": false
+                "type": "text",
+                "required": false
             }
         }
     }

--- a/ramses/utils.py
+++ b/ramses/utils.py
@@ -212,7 +212,6 @@ def attr_subresource(raml_resource, route_name):
     properties = schema.get('properties', {})
     if route_name in properties:
         db_settings = properties[route_name].get('_db_settings', {})
-        db_settings = clean_db_properties(db_settings)
         return db_settings.get('type') in ('dict', 'list')
     return False
 
@@ -232,7 +231,6 @@ def singular_subresource(raml_resource, route_name):
         return False
 
     db_settings = properties[route_name].get('_db_settings', {})
-    db_settings = clean_db_properties(db_settings)
     is_obj = db_settings.get('type') == 'relationship'
     single_obj = not db_settings.get('uselist', True)
     return is_obj and single_obj
@@ -290,18 +288,3 @@ def get_resource_children(raml_resource):
     path = raml_resource.path
     return [res for res in raml_resource.root.resources
             if res.parent and res.parent.path == path]
-
-
-def clean_db_properties(properties):
-    """ Remove prefix underscore from ramses DB properties keys.
-
-    DB properties are defined in JSON schema and are used to set up
-    DB fields.
-
-    :param properties: Dict of DB properties names defined in JSON schema.
-    """
-    cleaned = {}
-    for key, value in properties.items():
-        key = key[1:] if key.startswith('_') else key
-        cleaned[key] = value
-    return cleaned

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -139,13 +139,13 @@ class TestGenerateModelCls(object):
         schema = self._test_schema()
         schema['properties']['progress'] = {
             "_db_settings": {
-                "_type": "float",
-                "_required": True,
-                "_default": 0,
-                "_before_validation": ["zoo"],
-                "_after_validation": ["foo"],
-                "_backref_after_validation": ["foo"],
-                "_backref_before_validation": ["foo"]
+                "type": "float",
+                "required": True,
+                "default": 0,
+                "before_validation": ["zoo"],
+                "after_validation": ["foo"],
+                "backref_after_validation": ["foo"],
+                "backref_before_validation": ["foo"]
             }
         }
         mock_res.return_value = 1
@@ -176,8 +176,8 @@ class TestGenerateModelCls(object):
         schema = self._test_schema()
         schema['properties']['progress'] = {
             "_db_settings": {
-                "_type": "float",
-                "_default": "{{foobar}}",
+                "type": "float",
+                "default": "{{foobar}}",
             }
         }
         mock_res.return_value = 1
@@ -229,7 +229,7 @@ class TestGenerateModelCls(object):
         from ramses import models
         schema = self._test_schema()
         schema['properties']['progress'] = {
-            '_db_settings': {'_type': 'foobar'}}
+            '_db_settings': {'type': 'foobar'}}
         mock_reg.mget.return_value = {'foo': 'bar'}
 
         with pytest.raises(ValueError) as ex:
@@ -243,8 +243,8 @@ class TestGenerateModelCls(object):
         schema = self._test_schema()
         schema['properties']['progress'] = {
             '_db_settings': {
-                '_type': 'relationship',
-                '_document': 'FooBar',
+                'type': 'relationship',
+                'document': 'FooBar',
             }
         }
         mock_reg.mget.return_value = {'foo': 'bar'}
@@ -257,8 +257,8 @@ class TestGenerateModelCls(object):
         schema = self._test_schema()
         schema['properties']['progress'] = {
             "_db_settings": {
-                "_type": "foreign_key",
-                "_ref_column_type": "string"
+                "type": "foreign_key",
+                "ref_column_type": "string"
             }
         }
         mock_reg.mget.return_value = {'foo': 'bar'}
@@ -272,8 +272,8 @@ class TestGenerateModelCls(object):
         schema = self._test_schema()
         schema['properties']['progress'] = {
             "_db_settings": {
-                "_type": "list",
-                "_item_type": "integer"
+                "type": "list",
+                "item_type": "integer"
             }
         }
         mock_reg.mget.return_value = {'foo': 'bar'}
@@ -286,7 +286,7 @@ class TestGenerateModelCls(object):
         from ramses import models
         schema = self._test_schema()
         schema['properties']['_public_fields'] = {
-            '_db_settings': {'_type': 'interval'}}
+            '_db_settings': {'type': 'interval'}}
         mock_reg.mget.return_value = {'foo': 'bar'}
         models.generate_model_cls(
             schema=schema, model_name='Story', raml_resource=1)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -125,10 +125,10 @@ class TestGenerateModelCls(object):
     def _test_schema(self):
         return {
             'properties': {},
-            'auth_model': False,
-            'public_fields': ['public_field1'],
-            'auth_fields': ['auth_field1'],
-            'nested_relationships': ['nested_field1']
+            '_auth_model': False,
+            '_public_fields': ['public_field1'],
+            '_auth_fields': ['auth_field1'],
+            '_nested_relationships': ['nested_field1']
         }
 
     @patch('ramses.models.resolve_to_callable')
@@ -138,14 +138,14 @@ class TestGenerateModelCls(object):
         models.engine.FloatField.reset_mock()
         schema = self._test_schema()
         schema['properties']['progress'] = {
-            "required": True,
-            "type": "float",
-            "args": {
-                "default": 0,
-                "before_validation": ["zoo"],
-                "after_validation": ["foo"],
-                "backref_after_validation": ["foo"],
-                "backref_before_validation": ["foo"]
+            "_db_settings": {
+                "_type": "float",
+                "_required": True,
+                "_default": 0,
+                "_before_validation": ["zoo"],
+                "_after_validation": ["foo"],
+                "_backref_after_validation": ["foo"],
+                "_backref_before_validation": ["foo"]
             }
         }
         mock_res.return_value = 1
@@ -175,8 +175,10 @@ class TestGenerateModelCls(object):
         models.engine.FloatField.reset_mock()
         schema = self._test_schema()
         schema['properties']['progress'] = {
-            "type": "float",
-            "args": {"default": "{{foobar}}"}
+            "_db_settings": {
+                "_type": "float",
+                "_default": "{{foobar}}",
+            }
         }
         mock_res.return_value = 1
         model_cls, auth_model = models.generate_model_cls(
@@ -189,8 +191,8 @@ class TestGenerateModelCls(object):
         from nefertari.authentication.models import AuthModelMethodsMixin
         from ramses import models
         schema = self._test_schema()
-        schema['properties']['progress'] = {}
-        schema['auth_model'] = True
+        schema['properties']['progress'] = {'_db_settings': {}}
+        schema['_auth_model'] = True
         mock_reg.mget.return_value = {'foo': 'bar'}
 
         model_cls, auth_model = models.generate_model_cls(
@@ -202,7 +204,7 @@ class TestGenerateModelCls(object):
         from nefertari.authentication.models import AuthModelMethodsMixin
         from ramses import models
         schema = self._test_schema()
-        schema['properties']['progress'] = {}
+        schema['properties']['progress'] = {'_db_settings': {}}
         mock_reg.mget.return_value = {'foo': 'bar'}
 
         model_cls, auth_model = models.generate_model_cls(
@@ -212,10 +214,22 @@ class TestGenerateModelCls(object):
         assert not issubclass(model_cls, models.engine.ESBaseDocument)
         assert not issubclass(model_cls, AuthModelMethodsMixin)
 
+    def test_no_db_settings(self, mock_reg):
+        from ramses import models
+        schema = self._test_schema()
+        schema['properties']['progress'] = {'type': 'pickle'}
+        mock_reg.mget.return_value = {'foo': 'bar'}
+
+        model_cls, auth_model = models.generate_model_cls(
+            schema=schema, model_name='Story', raml_resource=None,
+            es_based=False)
+        assert not models.engine.PickleField.called
+
     def test_unknown_field_type(self, mock_reg):
         from ramses import models
         schema = self._test_schema()
-        schema['properties']['progress'] = {'type': 'foobar'}
+        schema['properties']['progress'] = {
+            '_db_settings': {'_type': 'foobar'}}
         mock_reg.mget.return_value = {'foo': 'bar'}
 
         with pytest.raises(ValueError) as ex:
@@ -228,8 +242,10 @@ class TestGenerateModelCls(object):
         from ramses import models
         schema = self._test_schema()
         schema['properties']['progress'] = {
-            'type': 'relationship',
-            'args': {'document': 'FooBar'}
+            '_db_settings': {
+                '_type': 'relationship',
+                '_document': 'FooBar',
+            }
         }
         mock_reg.mget.return_value = {'foo': 'bar'}
         models.generate_model_cls(
@@ -240,9 +256,9 @@ class TestGenerateModelCls(object):
         from ramses import models
         schema = self._test_schema()
         schema['properties']['progress'] = {
-            "type": "foreign_key",
-            "args": {
-                "ref_column_type": "string"
+            "_db_settings": {
+                "_type": "foreign_key",
+                "_ref_column_type": "string"
             }
         }
         mock_reg.mget.return_value = {'foo': 'bar'}
@@ -255,9 +271,9 @@ class TestGenerateModelCls(object):
         from ramses import models
         schema = self._test_schema()
         schema['properties']['progress'] = {
-            "type": "list",
-            "args": {
-                "item_type": "integer"
+            "_db_settings": {
+                "_type": "list",
+                "_item_type": "integer"
             }
         }
         mock_reg.mget.return_value = {'foo': 'bar'}
@@ -269,7 +285,8 @@ class TestGenerateModelCls(object):
     def test_duplicate_field_name(self, mock_reg):
         from ramses import models
         schema = self._test_schema()
-        schema['properties']['_public_fields'] = {'type': 'interval'}
+        schema['properties']['_public_fields'] = {
+            '_db_settings': {'_type': 'interval'}}
         mock_reg.mget.return_value = {'foo': 'bar'}
         models.generate_model_cls(
             schema=schema, model_name='Story', raml_resource=1)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -245,7 +245,7 @@ class TestUtils(object):
             'properties': {
                 'route_name': {
                     '_db_settings': {
-                        '_type': 'string'
+                        'type': 'string'
                     }
                 }
             }
@@ -263,12 +263,12 @@ class TestUtils(object):
             'properties': {
                 'route_name': {
                     '_db_settings': {
-                        '_type': 'dict'
+                        'type': 'dict'
                     }
                 },
                 'route_name2': {
                     '_db_settings': {
-                        '_type': 'list'
+                        'type': 'list'
                     }
                 }
             }
@@ -304,7 +304,7 @@ class TestUtils(object):
             'properties': {
                 'route_name': {
                     '_db_settings': {
-                        '_type': 'string'
+                        'type': 'string'
                     }
                 }
             }
@@ -322,8 +322,8 @@ class TestUtils(object):
             'properties': {
                 'route_name': {
                     '_db_settings': {
-                        '_type': 'relationship',
-                        '_uselist': False
+                        'type': 'relationship',
+                        'uselist': False
                     }
                 },
             }

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -244,7 +244,9 @@ class TestUtils(object):
         mock_schema.return_value = {
             'properties': {
                 'route_name': {
-                    'type': 'string'
+                    '_db_settings': {
+                        '_type': 'string'
+                    }
                 }
             }
         }
@@ -260,10 +262,14 @@ class TestUtils(object):
         mock_schema.return_value = {
             'properties': {
                 'route_name': {
-                    'type': 'dict'
+                    '_db_settings': {
+                        '_type': 'dict'
+                    }
                 },
                 'route_name2': {
-                    'type': 'list'
+                    '_db_settings': {
+                        '_type': 'list'
+                    }
                 }
             }
         }
@@ -297,7 +303,9 @@ class TestUtils(object):
         mock_schema.return_value = {
             'properties': {
                 'route_name': {
-                    'type': 'string'
+                    '_db_settings': {
+                        '_type': 'string'
+                    }
                 }
             }
         }
@@ -313,8 +321,10 @@ class TestUtils(object):
         mock_schema.return_value = {
             'properties': {
                 'route_name': {
-                    'type': 'relationship',
-                    'args': {'uselist': False}
+                    '_db_settings': {
+                        '_type': 'relationship',
+                        '_uselist': False
+                    }
                 },
             }
         }


### PR DESCRIPTION
Renames:
* auth_fields -> _auth_fields
* public_fields -> _public_fields
* nested_relationships -> _nested_relationships
* auth_model -> _auth_model

Changes:
* JSON schema now defines what it should to - schema of JSON body that should be posted to web API.
* DB field settings are now defined in `root.properties.fieldname._db_settings`.
* DB fields are only generated from JSON schema properties which define `_db_settings`