### PR TITLE
Rework creation of related models

### DIFF
--- a/ramses/generators.py
+++ b/ramses/generators.py
@@ -157,7 +157,6 @@ def generate_models(config, raml_resources):
     from .models import handle_model_generation
     if not raml_resources:
         return
-
     for raml_resource in raml_resources:
         # No need to generate models for dynamic resource
         if is_dynamic_uri(raml_resource.path):

--- a/ramses/models.py
+++ b/ramses/models.py
@@ -1,6 +1,7 @@
 import logging
 
 from nefertari import engine
+from inflection import pluralize
 
 from .utils import (
     resolve_to_callable, is_callable_tag,
@@ -55,7 +56,7 @@ def get_existing_model(model_name):
         log.debug('Model `{}` does not exist'.format(model_name))
 
 
-def prepare_relationship(config, field_name, model_name, raml_resource):
+def prepare_relationship(config, model_name, raml_resource):
     """ Create referenced model if it doesn't exist.
 
     When preparing a relationship, we check to see if the model that will be
@@ -63,20 +64,21 @@ def prepare_relationship(config, field_name, model_name, raml_resource):
     to use it in a relationship. Thus the first usage of this model in RAML file
     must provide its schema in POST method resource body schema.
 
-    :param field_name: Name of the field that should become a `Relationship`.
     :param model_name: Name of model which should be generated.
     :param raml_resource: Instance of ramlfications.raml.ResourceNode for
         which :model_name: will be defined.
     """
     if get_existing_model(model_name) is None:
+        plural_route = '/' + pluralize(model_name.lower())
+        route = '/' + model_name.lower()
         for res in raml_resource.root.resources:
             if res.method.upper() != 'POST':
                 continue
-            if res.path.endswith('/' + field_name):
+            if res.path.endswith(plural_route) or res.path.endswith(route):
                 break
         else:
-            raise ValueError('Model `{}` used in relationship `{}` is not '
-                             'defined'.format(model_name, field_name))
+            raise ValueError('Model `{}` used in relationship is not '
+                             'defined'.format(model_name))
         setup_data_model(config, res, model_name)
 
 
@@ -146,7 +148,7 @@ def generate_model_cls(config, schema, model_name, raml_resource,
 
         if field_cls is engine.Relationship:
             prepare_relationship(
-                config, field_name, field_kwargs['document'],
+                config, field_kwargs['document'],
                 raml_resource)
         if field_cls is engine.ForeignKeyField:
             key = 'ref_column_type'

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -29,7 +29,7 @@ class TestHelperFunctions(object):
         from ramses import models
         config = Mock()
         models.prepare_relationship(
-            config, 'foobar', 'Story', 'raml_resource')
+            config, 'Story', 'raml_resource')
         mock_get.assert_called_once_with('Story')
         assert not mock_set.called
 
@@ -44,9 +44,8 @@ class TestHelperFunctions(object):
         ]))
         mock_get.return_value = None
         with pytest.raises(ValueError) as ex:
-            models.prepare_relationship(
-                config, 'stories', 'Story', resource)
-        expected = ('Model `Story` used in relationship `stories` '
+            models.prepare_relationship(config, 'Story', resource)
+        expected = ('Model `Story` used in relationship '
                     'is not defined')
         assert str(ex.value) == expected
 
@@ -64,7 +63,7 @@ class TestHelperFunctions(object):
         ]))
         mock_get.return_value = None
         config = config_mock()
-        models.prepare_relationship(config, 'stories', 'Story', resource)
+        models.prepare_relationship(config, 'Story', resource)
         mock_set.assert_called_once_with(config, matching_res, 'Story')
 
     @patch('ramses.models.get_existing_model')
@@ -306,7 +305,7 @@ class TestGenerateModelCls(object):
             config, schema=schema, model_name='Story',
             raml_resource=1)
         mock_prep.assert_called_once_with(
-            config, 'progress', 'FooBar', 1)
+            config, 'FooBar', 1)
 
     def test_foreignkey_field(
             self, mock_reg, mock_subscribers, mock_proc):


### PR DESCRIPTION
When generating related model, model name is used to look up
routes instead of field name. Both singular and plural
version of lowercased model name are user in look up.