### PR TITLE
Fix config.registry.auth_model missing properties crashing the server on startup

### DIFF
--- a/ramses/models.py
+++ b/ramses/models.py
@@ -181,10 +181,11 @@ def setup_data_model(config, raml_resource, model_name):
     :param model_name: String representing model name.
     """
     model_cls = get_existing_model(model_name)
-    if model_cls is not None:
-        return model_cls, False
-
     schema = resource_schema(raml_resource)
+
+    if model_cls is not None:
+        return model_cls, schema.get('_auth_model', False)
+
     if not schema:
         raise Exception('Missing schema for model `{}`'.format(model_name))
 


### PR DESCRIPTION
Bug fixed: If the resource designated as the auth model is declared after a resource that depends on it in the main raml file, then config.registry.auth_model is not properly populated and the server will crash on startup.

Fix: Added an additional check when the model already exists to see if the model is designated as the auth model.
