### PR TITLE
Fix config.registry.auth_model missing properties crashing the server on startup

### DIFF
--- a/ramses/models.py
+++ b/ramses/models.py
@@ -181,10 +181,11 @@ def setup_data_model(config, raml_resource, model_name):
     :param model_name: String representing model name.
     """
     model_cls = get_existing_model(model_name)
-    if model_cls is not None:
-        return model_cls, False
-
     schema = resource_schema(raml_resource)
+
+    if model_cls is not None:
+        return model_cls, schema.get('_auth_model', False)
+
     if not schema:
         raise Exception('Missing schema for model `{}`'.format(model_name))
 

--- a/ramses/models.py
+++ b/ramses/models.py
@@ -183,11 +183,11 @@ def setup_data_model(config, raml_resource, model_name):
     model_cls = get_existing_model(model_name)
     schema = resource_schema(raml_resource)
 
-    if model_cls is not None:
-        return model_cls, schema.get('_auth_model', False)
-
     if not schema:
         raise Exception('Missing schema for model `{}`'.format(model_name))
+
+    if model_cls is not None:
+        return model_cls, schema.get('_auth_model', False)
 
     log.info('Generating model class `{}`'.format(model_name))
     return generate_model_cls(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -66,13 +66,27 @@ class TestHelperFunctions(object):
         models.prepare_relationship(config, 'Story', resource)
         mock_set.assert_called_once_with(config, matching_res, 'Story')
 
+    @patch('ramses.models.resource_schema')
     @patch('ramses.models.get_existing_model')
-    def test_setup_data_model_existing_model(self, mock_get):
+    def test_setup_data_model_existing_model(self, mock_get, mock_schema):
         from ramses import models
         config = Mock()
         mock_get.return_value = 1
+        mock_schema.return_value = {"foo": "bar"}
         model, auth_model = models.setup_data_model(config, 'foo', 'Bar')
         assert not auth_model
+        assert model == 1
+        mock_get.assert_called_once_with('Bar')
+
+    @patch('ramses.models.resource_schema')
+    @patch('ramses.models.get_existing_model')
+    def test_setup_data_model_existing_auth_model(self, mock_get, mock_schema):
+        from ramses import models
+        config = Mock()
+        mock_get.return_value = 1
+        mock_schema.return_value = {"_auth_model": True}
+        model, auth_model = models.setup_data_model(config, 'foo', 'Bar')
+        assert auth_model
         assert model == 1
         mock_get.assert_called_once_with('Bar')
 


### PR DESCRIPTION
Bug fixed: If the resource designated as the auth model is declared after a resource that depends on it in the main raml file, then config.registry.auth_model is not properly populated and the server will crash on startup.

Fix: Added an additional check when the model already exists to see if the model is designated as the auth model.

I also added a test case for this situation.